### PR TITLE
add support for extrabar mentioned in #8

### DIFF
--- a/dwm-status2d-extrabar-a786211-6.4.diff
+++ b/dwm-status2d-extrabar-a786211-6.4.diff
@@ -1,0 +1,402 @@
+diff --git a/config.def.h b/config.def.h
+index 9efa774..15053ce 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -3,8 +3,10 @@
+ /* appearance */
+ static const unsigned int borderpx  = 1;        /* border pixel of windows */
+ static const unsigned int snap      = 32;       /* snap pixel */
+-static const int showbar            = 1;        /* 0 means no bar */
+-static const int topbar             = 1;        /* 0 means bottom bar */
++static const int showbar            = 1;        /* 0 means no standard bar */
++static const int topbar             = 1;        /* 0 means standard bar at bottom */
++static const int extrabar           = 1;        /* 0 means no extra bar */
++static const char statussep         = ';';      /* separator between statuses */
+ static const char *fonts[]          = { "monospace:size=10" };
+ static const char dmenufont[]       = "monospace:size=10";
+ static const char col_gray1[]       = "#222222";
+@@ -65,6 +67,7 @@ static const Key keys[] = {
+ 	{ MODKEY,                       XK_p,      spawn,          {.v = dmenucmd } },
+ 	{ MODKEY|ShiftMask,             XK_Return, spawn,          {.v = termcmd } },
+ 	{ MODKEY,                       XK_b,      togglebar,      {0} },
++	{ MODKEY|ShiftMask,             XK_b,      toggleextrabar, {0} },
+ 	{ MODKEY,                       XK_j,      focusstack,     {.i = +1 } },
+ 	{ MODKEY,                       XK_k,      focusstack,     {.i = -1 } },
+ 	{ MODKEY,                       XK_i,      incnmaster,     {.i = +1 } },
+@@ -105,6 +108,9 @@ static const Button buttons[] = {
+ 	{ ClkLtSymbol,          0,              Button3,        setlayout,      {.v = &layouts[2]} },
+ 	{ ClkWinTitle,          0,              Button2,        zoom,           {0} },
+ 	{ ClkStatusText,        0,              Button2,        spawn,          {.v = termcmd } },
++	{ ClkExBarLeftStatus,   0,              Button2,        spawn,          {.v = termcmd } },
++	{ ClkExBarMiddle,       0,              Button2,        spawn,          {.v = termcmd } },
++	{ ClkExBarRightStatus,  0,              Button2,        spawn,          {.v = termcmd } },
+ 	{ ClkClientWin,         MODKEY,         Button1,        movemouse,      {0} },
+ 	{ ClkClientWin,         MODKEY,         Button2,        togglefloating, {0} },
+ 	{ ClkClientWin,         MODKEY,         Button3,        resizemouse,    {0} },
+diff --git a/dwm.c b/dwm.c
+index 253aba7..eaa1ca2 100644
+--- a/dwm.c
++++ b/dwm.c
+@@ -65,6 +65,7 @@ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
+        NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms */
+ enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
+ enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
++       ClkExBarLeftStatus, ClkExBarMiddle, ClkExBarRightStatus,
+        ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
+ 
+ typedef union {
+@@ -117,6 +118,7 @@ struct Monitor {
+ 	int nmaster;
+ 	int num;
+ 	int by;               /* bar geometry */
++	int eby;              /* extra bar geometry */
+ 	int mx, my, mw, mh;   /* screen size */
+ 	int wx, wy, ww, wh;   /* window area  */
+ 	unsigned int seltags;
+@@ -124,11 +126,13 @@ struct Monitor {
+ 	unsigned int tagset[2];
+ 	int showbar;
+ 	int topbar;
++	int extrabar;
+ 	Client *clients;
+ 	Client *sel;
+ 	Client *stack;
+ 	Monitor *next;
+ 	Window barwin;
++	Window extrabarwin;
+ 	const Layout *lt[2];
+ };
+ 
+@@ -163,6 +167,7 @@ static void detachstack(Client *c);
+ static Monitor *dirtomon(int dir);
+ static void drawbar(Monitor *m);
+ static void drawbars(void);
++static int drawstatusbar(Monitor *m, int bh, char* text, int isRightStatus);
+ static void enternotify(XEvent *e);
+ static void expose(XEvent *e);
+ static void focus(Client *c);
+@@ -211,6 +216,7 @@ static void tag(const Arg *arg);
+ static void tagmon(const Arg *arg);
+ static void tile(Monitor *m);
+ static void togglebar(const Arg *arg);
++static void toggleextrabar(const Arg *arg);
+ static void togglefloating(const Arg *arg);
+ static void toggletag(const Arg *arg);
+ static void toggleview(const Arg *arg);
+@@ -237,7 +243,9 @@ static void zoom(const Arg *arg);
+ 
+ /* variables */
+ static const char broken[] = "broken";
+-static char stext[256];
++static char stext[1024];
++static char estextl[1024];
++static char estextr[1024];
+ static int screen;
+ static int sw, sh;           /* X display screen geometry width, height */
+ static int bh;               /* bar height */
+@@ -446,6 +454,13 @@ buttonpress(XEvent *e)
+ 			click = ClkStatusText;
+ 		else
+ 			click = ClkWinTitle;
++	} else if (ev->window == selmon->extrabarwin) {
++		if (ev->x < (int)TEXTW(estextl))
++			click = ClkExBarLeftStatus;
++		else if (ev->x > selmon->ww - (int)TEXTW(estextr))
++			click = ClkExBarRightStatus;
++		else
++			click = ClkExBarMiddle;
+ 	} else if ((c = wintoclient(ev->window))) {
+ 		focus(c);
+ 		restack(selmon);
+@@ -487,7 +502,7 @@ cleanup(void)
+ 		cleanupmon(mons);
+ 	for (i = 0; i < CurLast; i++)
+ 		drw_cur_free(drw, cursor[i]);
+-	for (i = 0; i < LENGTH(colors); i++)
++	for (i = 0; i < LENGTH(colors) + 1; i++)
+ 		free(scheme[i]);
+ 	free(scheme);
+ 	XDestroyWindow(dpy, wmcheckwin);
+@@ -509,7 +524,9 @@ cleanupmon(Monitor *mon)
+ 		m->next = mon->next;
+ 	}
+ 	XUnmapWindow(dpy, mon->barwin);
++	XUnmapWindow(dpy, mon->extrabarwin);
+ 	XDestroyWindow(dpy, mon->barwin);
++	XDestroyWindow(dpy, mon->extrabarwin);
+ 	free(mon);
+ }
+ 
+@@ -572,6 +589,7 @@ configurenotify(XEvent *e)
+ 					if (c->isfullscreen)
+ 						resizeclient(c, m->mx, m->my, m->mw, m->mh);
+ 				XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, m->ww, bh);
++				XMoveResizeWindow(dpy, m->extrabarwin, m->wx, m->eby, m->ww, bh);
+ 			}
+ 			focus(NULL);
+ 			arrange(NULL);
+@@ -642,6 +660,7 @@ createmon(void)
+ 	m->nmaster = nmaster;
+ 	m->showbar = showbar;
+ 	m->topbar = topbar;
++	m->extrabar = extrabar;
+ 	m->lt[0] = &layouts[0];
+ 	m->lt[1] = &layouts[1 % LENGTH(layouts)];
+ 	strncpy(m->ltsymbol, layouts[0].symbol, sizeof m->ltsymbol);
+@@ -696,10 +715,121 @@ dirtomon(int dir)
+ 	return m;
+ }
+ 
++int
++drawstatusbar(Monitor *m, int bh, char* stext, int isRightStatus) {
++	int ret, i, w, x, len;
++	short isCode = 0;
++	char *text;
++	char *p;
++
++	len = strlen(stext) + 1 ;
++	if (!(text = (char*) malloc(sizeof(char)*len)))
++		die("malloc");
++	p = text;
++	memcpy(text, stext, len);
++
++	/* compute width of the status text */
++	w = 0;
++	i = -1;
++	while (text[++i]) {
++		if (text[i] == '^') {
++			if (!isCode) {
++				isCode = 1;
++				text[i] = '\0';
++				w += TEXTW(text) - lrpad;
++				text[i] = '^';
++				if (text[++i] == 'f')
++					w += atoi(text + ++i);
++			} else {
++				isCode = 0;
++				text = text + i + 1;
++				i = -1;
++			}
++		}
++	}
++	if (!isCode)
++		w += TEXTW(text) - lrpad;
++	else
++		isCode = 0;
++	text = p;
++
++	w += 2; /* 1px padding on both sides */
++	if (isRightStatus)
++		ret = x = m->ww - w;
++	else
++		ret = x = 5;
++
++	drw_setscheme(drw, scheme[LENGTH(colors)]);
++	drw->scheme[ColFg] = scheme[SchemeNorm][ColFg];
++	drw->scheme[ColBg] = scheme[SchemeNorm][ColBg];
++	drw_rect(drw, x, 0, w, bh, 1, 1);
++	x++;
++
++	/* process status text */
++	i = -1;
++	while (text[++i]) {
++		if (text[i] == '^' && !isCode) {
++			isCode = 1;
++
++			text[i] = '\0';
++			w = TEXTW(text) - lrpad;
++			drw_text(drw, x, 0, w, bh, 0, text, 0);
++
++			x += w;
++
++			/* process code */
++			while (text[++i] != '^') {
++				if (text[i] == 'c') {
++					char buf[8];
++					memcpy(buf, (char*)text+i+1, 7);
++					buf[7] = '\0';
++					drw_clr_create(drw, &drw->scheme[ColFg], buf);
++					i += 7;
++				} else if (text[i] == 'b') {
++					char buf[8];
++					memcpy(buf, (char*)text+i+1, 7);
++					buf[7] = '\0';
++					drw_clr_create(drw, &drw->scheme[ColBg], buf);
++					i += 7;
++				} else if (text[i] == 'd') {
++					drw->scheme[ColFg] = scheme[SchemeNorm][ColFg];
++					drw->scheme[ColBg] = scheme[SchemeNorm][ColBg];
++				} else if (text[i] == 'r') {
++					int rx = atoi(text + ++i);
++					while (text[++i] != ',');
++					int ry = atoi(text + ++i);
++					while (text[++i] != ',');
++					int rw = atoi(text + ++i);
++					while (text[++i] != ',');
++					int rh = atoi(text + ++i);
++
++					drw_rect(drw, rx + x, ry, rw, rh, 1, 0);
++				} else if (text[i] == 'f') {
++					x += atoi(text + ++i);
++				}
++			}
++
++			text = text + i + 1;
++			i=-1;
++			isCode = 0;
++		}
++	}
++
++	if (!isCode) {
++		w = TEXTW(text) - lrpad;
++		drw_text(drw, x, 0, w, bh, 0, text, 0);
++	}
++
++	drw_setscheme(drw, scheme[SchemeNorm]);
++	free(p);
++
++	return ret;
++}
++
+ void
+ drawbar(Monitor *m)
+ {
+-	int x, w, tw = 0;
++	int x, w, tw = 0, etwl = 0, etwr = 0;
+ 	int boxs = drw->fonts->h / 9;
+ 	int boxw = drw->fonts->h / 6 + 2;
+ 	unsigned int i, occ = 0, urg = 0;
+@@ -710,9 +840,7 @@ drawbar(Monitor *m)
+ 
+ 	/* draw status first so it can be overdrawn by tags later */
+ 	if (m == selmon) { /* status is only drawn on selected monitor */
+-		drw_setscheme(drw, scheme[SchemeNorm]);
+-		tw = TEXTW(stext) - lrpad + 2; /* 2px right padding */
+-		drw_text(drw, m->ww - tw, 0, tw, bh, 0, stext, 0);
++		tw = m->ww - drawstatusbar(m, bh, stext, 1);
+ 	}
+ 
+ 	for (c = m->clients; c; c = c->next) {
+@@ -747,6 +875,15 @@ drawbar(Monitor *m)
+ 		}
+ 	}
+ 	drw_map(drw, m->barwin, 0, 0, m->ww, bh);
++
++	if (m == selmon) { /* extra status is only drawn on selected monitor */
++		drw_setscheme(drw, scheme[SchemeNorm]);
++		/* clear default bar draw buffer by drawing a blank rectangle */
++		drw_rect(drw, 0, 0, m->ww, bh, 1, 1);
++		etwr += m->ww - drawstatusbar(m, bh, estextr, 1);
++		etwl += drawstatusbar(m, bh, estextl, 0);
++		drw_map(drw, m->extrabarwin, 0, 0, m->ww, bh);
++	}
+ }
+ 
+ void
+@@ -1568,7 +1705,8 @@ setup(void)
+ 	cursor[CurResize] = drw_cur_create(drw, XC_sizing);
+ 	cursor[CurMove] = drw_cur_create(drw, XC_fleur);
+ 	/* init appearance */
+-	scheme = ecalloc(LENGTH(colors), sizeof(Clr *));
++	scheme = ecalloc(LENGTH(colors) + 1, sizeof(Clr *));
++	scheme[LENGTH(colors)] = drw_scm_create(drw, colors[0], 3);
+ 	for (i = 0; i < LENGTH(colors); i++)
+ 		scheme[i] = drw_scm_create(drw, colors[i], 3);
+ 	/* init bars */
+@@ -1705,6 +1843,15 @@ togglebar(const Arg *arg)
+ 	arrange(selmon);
+ }
+ 
++void
++toggleextrabar(const Arg *arg)
++{
++	selmon->extrabar = !selmon->extrabar;
++	updatebarpos(selmon);
++	XMoveResizeWindow(dpy, selmon->extrabarwin, selmon->wx, selmon->eby, selmon->ww, bh);
++	arrange(selmon);
++}
++
+ void
+ togglefloating(const Arg *arg)
+ {
+@@ -1810,14 +1957,22 @@ updatebars(void)
+ 	};
+ 	XClassHint ch = {"dwm", "dwm"};
+ 	for (m = mons; m; m = m->next) {
+-		if (m->barwin)
+-			continue;
+-		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, m->ww, bh, 0, DefaultDepth(dpy, screen),
+-				CopyFromParent, DefaultVisual(dpy, screen),
+-				CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
+-		XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
+-		XMapRaised(dpy, m->barwin);
+-		XSetClassHint(dpy, m->barwin, &ch);
++		if (!m->barwin) {
++			m->barwin = XCreateWindow(dpy, root, m->wx, m->by, m->ww, bh, 0, DefaultDepth(dpy, screen),
++					CopyFromParent, DefaultVisual(dpy, screen),
++					CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
++			XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
++			XMapRaised(dpy, m->barwin);
++			XSetClassHint(dpy, m->barwin, &ch);
++		}
++		if (!m->extrabarwin) {
++			m->extrabarwin = XCreateWindow(dpy, root, m->wx, m->eby, m->ww, bh, 0, DefaultDepth(dpy, screen),
++					CopyFromParent, DefaultVisual(dpy, screen),
++					CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
++			XDefineCursor(dpy, m->extrabarwin, cursor[CurNormal]->cursor);
++			XMapRaised(dpy, m->extrabarwin);
++			XSetClassHint(dpy, m->extrabarwin, &ch);
++		}
+ 	}
+ }
+ 
+@@ -1832,6 +1987,12 @@ updatebarpos(Monitor *m)
+ 		m->wy = m->topbar ? m->wy + bh : m->wy;
+ 	} else
+ 		m->by = -bh;
++	if (m->extrabar) {
++		m->wh -= bh;
++		m->eby = !m->topbar ? m->wy : m->wy + m->wh;
++		m->wy = !m->topbar ? m->wy + bh : m->wy;
++	} else
++		m->eby = -bh;
+ }
+ 
+ void
+@@ -1989,8 +2150,26 @@ updatesizehints(Client *c)
+ void
+ updatestatus(void)
+ {
+-	if (!gettextprop(root, XA_WM_NAME, stext, sizeof(stext)))
++	char text[768];
++	if (!gettextprop(root, XA_WM_NAME, text, sizeof(text))) {
+ 		strcpy(stext, "dwm-"VERSION);
++		estextl[0] = '\0';
++		estextr[0] = '\0';
++	} else {
++		char *l = strchr(text, statussep);
++		if (l) {
++			*l = '\0'; l++;
++			strncpy(estextl, l, sizeof(estextl) - 1);
++		} else
++			estextl[0] = '\0';
++		char *r = strchr(estextl, statussep);
++		if (r) {
++			*r = '\0'; r++;
++			strncpy(estextr, r, sizeof(estextr) - 1);
++		} else
++			estextr[0] = '\0';
++		strncpy(stext, text, sizeof(stext) - 1);
++	}
+ 	drawbar(selmon);
+ }
+ 
+@@ -2069,7 +2248,7 @@ wintomon(Window w)
+ 	if (w == root && getrootptr(&x, &y))
+ 		return recttomon(x, y, 1, 1);
+ 	for (m = mons; m; m = m->next)
+-		if (w == m->barwin)
++		if (w == m->barwin || w == m->extrabarwin)
+ 			return m;
+ 	if ((c = wintoclient(w)))
+ 		return c->mon;


### PR DESCRIPTION
## This adds support for bottombar/extrabar as mentioned in #8.

This is a combined patch of `dwm-status2d-6.3.diff` and `dwm-extrabar-6.2-20210930-a786211.diff`.

This patch adds colours to all three corners of the status bar oppose to only Top Right, when there is an extrabar (i.e. `extrabar` patch).

Feel free to modify and change as you wish.

![Screenshot_2022-11-27_15-02-46](https://user-images.githubusercontent.com/89329547/204127211-8c0a6445-2775-4308-855a-3c0f5504f57d.png)